### PR TITLE
Fixing a bug and updating the documentation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PairAvalanchesQED"
 uuid = "bd4b498a-a695-4147-a586-26c198ec51ab"
 authors = ["Anthony Mercuri-Baron <anthony.mercuri@protonmail.com>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 Einsum = "b7d42ee7-0b51-5a75-98ca-779d3107e4c0"

--- a/README.md
+++ b/README.md
@@ -236,3 +236,11 @@ In the following will be explained the intermediate functions used to build `wef
     * `f1` is the array of the components of the `f1` eigen 4-vector over space.
 
 
+## Dependencies
+
+This code uses the following other Julia packages:
+  * [Einsum.jl](https://github.com/ahwillia/Einsum.jl)
+  * [JLD.jl](https://github.com/JuliaIO/JLD.jl)
+  * [QuadGK.jl](https://github.com/JuliaMath/QuadGK.jl)
+  * [Roots.jl](https://github.com/JuliaMath/Roots.jl)
+  * [SpecialFunctions.jl](https://github.com/JuliaMath/SpecialFunctions.jl)

--- a/src/AvalancheModelRotatingConfigs.jl
+++ b/src/AvalancheModelRotatingConfigs.jl
@@ -136,8 +136,8 @@ end
 export GR_pure_rotating
 
 function GR_pure_rotating(epsilon,lambda=8e-7,chi_switch=10,beta=1,tem_precision=1e-4)
-    tem = solve_tem(epsilon,weff,lambda,beta,tem_precision)
-    chi_em = chi_e(epsilon,weff,tem,lambda)
+    tem = solve_tem(epsilon,0.5,lambda,beta,tem_precision) # for pure rotating field weff = 0.5 omega
+    chi_em = chi_e(epsilon,0.5,tem,lambda)
     if chi_em < chi_switch
         return GR_pure_rotating_MidIntensity(epsilon,lambda,beta,tem_precision)
     else 


### PR DESCRIPTION
The global growth rate function for pure rotating field case had the weff variable used in it without being declared.